### PR TITLE
[GHI#77] Design home screen dashboard with stats, matches, missions, and logs

### DIFF
--- a/convex/games.ts
+++ b/convex/games.ts
@@ -47,12 +47,16 @@ export const getRecentGames = query({
     const [asP1, asP2] = await Promise.all([
       ctx.db
         .query("games")
-        .withIndex("by_p1_updatedTime", (q) => q.eq("p1UserId", userId))
+        .withIndex("by_status_p1_updatedTime", (q) =>
+          q.eq("status", "ended").eq("p1UserId", userId),
+        )
         .order("desc")
         .take(RECENT_GAMES_FETCH_LIMIT),
       ctx.db
         .query("games")
-        .withIndex("by_p2_updatedTime", (q) => q.eq("p2UserId", userId))
+        .withIndex("by_status_p2_updatedTime", (q) =>
+          q.eq("status", "ended").eq("p2UserId", userId),
+        )
         .order("desc")
         .take(RECENT_GAMES_FETCH_LIMIT),
     ]);

--- a/convex/model/games.ts
+++ b/convex/model/games.ts
@@ -19,6 +19,8 @@ import type {
 export const HEARTBEAT_FRESH_MS = 60000;
 export const PAUSE_TIMEOUT_MS = 5 * 60_000;
 export const DEFAULT_TURN_DURATION_MS = 3000;
+export const RECENT_GAMES_LIMIT = 30;
+export const RECENT_GAMES_FETCH_LIMIT = RECENT_GAMES_LIMIT + 1;
 
 type Ctx = MutationCtx | QueryCtx;
 type GameDoc = Doc<"games">;

--- a/convex/schemas/game.ts
+++ b/convex/schemas/game.ts
@@ -97,4 +97,6 @@ export const GameSchema = defineTable({
   updatedTime: v.number(),
 })
   .index("by_updatedTime", ["updatedTime"])
+  .index("by_p1_updatedTime", ["p1UserId", "updatedTime"])
+  .index("by_p2_updatedTime", ["p2UserId", "updatedTime"])
   .index("by_status_p2_createdTime", ["status", "p2UserId"]);

--- a/convex/schemas/game.ts
+++ b/convex/schemas/game.ts
@@ -99,4 +99,6 @@ export const GameSchema = defineTable({
   .index("by_updatedTime", ["updatedTime"])
   .index("by_p1_updatedTime", ["p1UserId", "updatedTime"])
   .index("by_p2_updatedTime", ["p2UserId", "updatedTime"])
+  .index("by_status_p1_updatedTime", ["status", "p1UserId", "updatedTime"])
+  .index("by_status_p2_updatedTime", ["status", "p2UserId", "updatedTime"])
   .index("by_status_p2_createdTime", ["status", "p2UserId"]);

--- a/src/infrastructure/convex/GameApi.ts
+++ b/src/infrastructure/convex/GameApi.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "convex/react";
 
 import { api } from "@/convex/_generated/api";
-import type { GameId as ConvexGameId, GameDoc } from "@/convex/schemas/game";
+import type { GameId as ConvexGameId } from "@/convex/schemas/game";
 import type { Game, GameId } from "@/domain/entities/Game";
 import { toDomainGame } from "@/infrastructure/convex/repository/gameRepository";
 
@@ -13,5 +13,14 @@ export const useGameById = (
     api.games.getGame,
     resolvedId ? { gameId: resolvedId } : "skip",
   );
-  return game ? toDomainGame(game as GameDoc) : game;
+  return game ? toDomainGame(game) : game;
+};
+
+export const useRecentGamesQuery = (): Game[] | undefined => {
+  const recentGames = useQuery(api.games.getRecentGames);
+  if (!recentGames) {
+    return recentGames;
+  }
+
+  return recentGames.games.map((game) => toDomainGame(game));
 };

--- a/src/ui/web/modules/home/components/HomeMatchCard.tsx
+++ b/src/ui/web/modules/home/components/HomeMatchCard.tsx
@@ -1,9 +1,16 @@
 import { ChevronRight } from "lucide-react";
 
+import { resolveAvatarSrc } from "@/domain/entities/Avatar";
 import { H6, Muted, Small } from "@/ui/web/components/Typography";
-import { Avatar, AvatarFallback } from "@/ui/web/components/ui/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/ui/web/components/ui/avatar";
 import { Card, CardContent } from "@/ui/web/components/ui/card";
-import { cn } from "@/ui/web/lib/utils";
+import { useCurrentUser, useUserById } from "@/ui/web/hooks/useUser";
+import { resolvePlayerLabel } from "@/ui/web/lib/user";
+import { cn, getFallbackInitials } from "@/ui/web/lib/utils";
 import type {
   HomeMatch,
   HomeMatchStatus,
@@ -37,10 +44,26 @@ export const HomeMatchCard = ({
   status,
   subtitle,
   time,
-  title,
-  opponentInitials,
+  opponentUserId,
 }: HomeMatch) => {
   const statusStyle = statusStyles[status];
+  const currentUser = useCurrentUser();
+  const opponentUser = useUserById(opponentUserId);
+
+  const currentName = resolvePlayerLabel(currentUser ?? {}, "You");
+  const opponentName = resolvePlayerLabel(opponentUser ?? {}, "Opponent");
+  const currentInitials = getFallbackInitials({
+    name: currentUser?.name,
+    username: currentUser?.username,
+    email: currentUser?.email,
+  });
+  const opponentInitials = getFallbackInitials({
+    name: opponentUser?.name,
+    username: opponentUser?.username,
+    email: opponentUser?.email,
+  });
+  const currentAvatar = resolveAvatarSrc(currentUser?.avatar);
+  const opponentAvatar = resolveAvatarSrc(opponentUser?.avatar);
 
   return (
     <Card className="group relative gap-0 overflow-hidden rounded-4xl py-0 shadow-[0_12px_28px_-24px_rgba(15,23,42,0.35)] transition-colors hover:bg-card/80 dark:shadow-[0_20px_48px_-36px_rgba(0,0,0,0.75)]">
@@ -64,7 +87,7 @@ export const HomeMatchCard = ({
               {time}
             </Small>
           </div>
-          <H6 className="truncate text-base">vs {title}</H6>
+          <H6 className="truncate text-base">vs {opponentName}</H6>
           <Muted className="mt-0 truncate text-xs text-muted-foreground">
             {subtitle}
           </Muted>
@@ -80,14 +103,16 @@ export const HomeMatchCard = ({
                   statusStyle.ring,
                 )}
               >
+                <AvatarImage src={currentAvatar} alt={currentName} />
                 <AvatarFallback className="bg-card font-semibold text-foreground">
-                  Y
+                  {currentInitials}
                 </AvatarFallback>
               </Avatar>
               <Avatar
                 size="lg"
                 className="border border-background bg-secondary text-foreground ring-2 ring-border/80"
               >
+                <AvatarImage src={opponentAvatar} alt={opponentName} />
                 <AvatarFallback className="bg-secondary font-semibold text-foreground">
                   {opponentInitials}
                 </AvatarFallback>

--- a/src/ui/web/modules/home/components/HomeMatchCard.tsx
+++ b/src/ui/web/modules/home/components/HomeMatchCard.tsx
@@ -1,0 +1,105 @@
+import { ChevronRight } from "lucide-react";
+
+import { H6, Muted, Small } from "@/ui/web/components/Typography";
+import { Avatar, AvatarFallback } from "@/ui/web/components/ui/avatar";
+import { Card, CardContent } from "@/ui/web/components/ui/card";
+import { cn } from "@/ui/web/lib/utils";
+import type {
+  HomeMatch,
+  HomeMatchStatus,
+} from "@/ui/web/modules/home/components/home.types";
+
+const statusStyles: Record<
+  HomeMatchStatus,
+  { badge: string; ring: string; text: string; rail: string }
+> = {
+  victory: {
+    badge: "bg-primary/18 text-primary",
+    ring: "ring-primary/70",
+    text: "Victory",
+    rail: "bg-primary/90",
+  },
+  defeat: {
+    badge: "bg-destructive/20 text-destructive",
+    ring: "ring-destructive/70",
+    text: "Defeat",
+    rail: "bg-destructive/90",
+  },
+  stalemate: {
+    badge: "bg-muted text-muted-foreground",
+    ring: "ring-muted-foreground/60",
+    text: "Stalemate",
+    rail: "bg-muted-foreground/90",
+  },
+};
+
+export const HomeMatchCard = ({
+  status,
+  subtitle,
+  time,
+  title,
+  opponentInitials,
+}: HomeMatch) => {
+  const statusStyle = statusStyles[status];
+
+  return (
+    <Card className="group relative gap-0 overflow-hidden rounded-4xl py-0 shadow-[0_12px_28px_-24px_rgba(15,23,42,0.35)] transition-colors hover:bg-card/80 dark:shadow-[0_20px_48px_-36px_rgba(0,0,0,0.75)]">
+      <span
+        aria-hidden
+        className={cn("absolute inset-y-0 left-0 w-1", statusStyle.rail)}
+      />
+      <CardContent className="flex items-center px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center gap-2">
+            <Small
+              variant="label"
+              className={cn(
+                "rounded-full px-2 py-1 text-[9px] leading-none",
+                statusStyle.badge,
+              )}
+            >
+              {statusStyle.text}
+            </Small>
+            <Small className="text-[10px] font-medium text-muted-foreground">
+              {time}
+            </Small>
+          </div>
+          <H6 className="truncate text-base">vs {title}</H6>
+          <Muted className="mt-0 truncate text-xs text-muted-foreground">
+            {subtitle}
+          </Muted>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <div className="flex -space-x-2">
+              <Avatar
+                size="lg"
+                className={cn(
+                  "border border-background bg-card text-foreground ring-2",
+                  statusStyle.ring,
+                )}
+              >
+                <AvatarFallback className="bg-card font-semibold text-foreground">
+                  Y
+                </AvatarFallback>
+              </Avatar>
+              <Avatar
+                size="lg"
+                className="border border-background bg-secondary text-foreground ring-2 ring-border/80"
+              >
+                <AvatarFallback className="bg-secondary font-semibold text-foreground">
+                  {opponentInitials}
+                </AvatarFallback>
+              </Avatar>
+            </div>
+            <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 rounded-full border border-border/60 bg-background px-1.5 py-0.5 text-[8px] font-semibold uppercase text-muted-foreground">
+              vs
+            </span>
+          </div>
+          <ChevronRight className="size-4 text-muted-foreground transition-colors group-hover:text-foreground" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/ui/web/modules/home/components/HomeMatches.test.tsx
+++ b/src/ui/web/modules/home/components/HomeMatches.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from "@testing-library/react";
+
+import type { Game } from "@/domain/entities/Game";
+
+import { HomeMatches } from "./HomeMatches";
+
+const useCurrentUserMock = vi.fn();
+
+vi.mock("@/ui/web/hooks/useUser", () => ({
+  useCurrentUser: () => useCurrentUserMock(),
+}));
+
+vi.mock("@/ui/web/modules/home/components/HomeMatchCard", () => ({
+  HomeMatchCard: ({
+    id,
+    status,
+    subtitle,
+    opponentUserId,
+  }: {
+    id: string;
+    status: string;
+    subtitle: string;
+    opponentUserId: string | null;
+  }) => <div>{`${id}|${status}|${subtitle}|${opponentUserId ?? "null"}`}</div>,
+}));
+
+const createGame = (overrides: Partial<Game>): Game => {
+  const now = Date.now();
+  return {
+    id: "game-id",
+    status: "ended",
+    board: [],
+    gridSize: 3,
+    winLength: 3,
+    match: {
+      format: "single",
+      targetWins: 1,
+      roundIndex: 1,
+      score: { P1: 0, P2: 0 },
+      matchWinner: null,
+      rounds: [],
+    },
+    p1UserId: "u1",
+    p2UserId: "u2",
+    currentTurn: "P1",
+    turnDurationMs: null,
+    turnDeadlineTime: null,
+    winner: null,
+    winningLine: null,
+    endedReason: "draw",
+    endedTime: now,
+    pausedTime: null,
+    abandonedBy: null,
+    presence: { P1: { lastSeenTime: now }, P2: { lastSeenTime: now } },
+    movesCount: 0,
+    version: 1,
+    lastMove: null,
+    updatedTime: now,
+    ...overrides,
+  };
+};
+
+describe("HomeMatches", () => {
+  it("splits recent/previous and maps status + mode labels", () => {
+    const now = Date.now();
+    useCurrentUserMock.mockReturnValue({ id: "u1" });
+
+    render(
+      <HomeMatches
+        endedGames={[
+          createGame({
+            id: "recent-win-timed",
+            p1UserId: "u1",
+            p2UserId: "u2",
+            winner: "P1",
+            endedReason: "win",
+            turnDurationMs: 3000,
+            updatedTime: now - 1_000,
+          }),
+          createGame({
+            id: "recent-defeat-bo3",
+            p1UserId: "u3",
+            p2UserId: "u1",
+            winner: "P1",
+            endedReason: "win",
+            match: {
+              format: "bo3",
+              targetWins: 2,
+              roundIndex: 1,
+              score: { P1: 0, P2: 0 },
+              matchWinner: null,
+              rounds: [],
+            },
+            updatedTime: now - 2_000,
+          }),
+          createGame({
+            id: "previous-stalemate-grid",
+            p1UserId: "u1",
+            p2UserId: "u4",
+            winner: null,
+            endedReason: "draw",
+            gridSize: 4,
+            updatedTime: now - 8 * 24 * 60 * 60 * 1000,
+          }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("recent-win-timed|victory|Timed Challenge|u2"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("recent-defeat-bo3|defeat|Best of Three|u3"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "previous-stalemate-grid|stalemate|Tactical Grid Mode|u4",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/no recent matches in the last 7 days/i),
+    ).not.toBeVisible();
+  });
+
+  it("handles missing current user and empty previous opponent slot fallback", () => {
+    useCurrentUserMock.mockReturnValue(null);
+    const now = Date.now();
+
+    render(
+      <HomeMatches
+        endedGames={[
+          createGame({
+            id: "no-user-game",
+            p1UserId: "u9",
+            p2UserId: null,
+            winner: "P1",
+            endedReason: "win",
+            updatedTime: now - 1000,
+          }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("no-user-game|stalemate|Classic Mode|u9"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/no recent matches in the last 7 days/i),
+    ).not.toBeVisible();
+  });
+
+  it("maps bo5 mode label correctly", () => {
+    const now = Date.now();
+    useCurrentUserMock.mockReturnValue({ id: "u1" });
+
+    render(
+      <HomeMatches
+        endedGames={[
+          createGame({
+            id: "bo5-match",
+            p1UserId: "u1",
+            p2UserId: "u7",
+            winner: "P1",
+            endedReason: "win",
+            match: {
+              format: "bo5",
+              targetWins: 3,
+              roundIndex: 1,
+              score: { P1: 0, P2: 0 },
+              matchWinner: null,
+              rounds: [],
+            },
+            updatedTime: now - 500,
+          }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("bo5-match|victory|Best of Five|u7"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/ui/web/modules/home/components/HomeMatches.tsx
+++ b/src/ui/web/modules/home/components/HomeMatches.tsx
@@ -1,0 +1,122 @@
+import { Activity } from "react";
+
+import type { Game, PlayerSlot } from "@/domain/entities/Game";
+import { P } from "@/ui/web/components/Typography";
+import { useCurrentUser } from "@/ui/web/hooks/useUser";
+import { HomeMatchCard } from "@/ui/web/modules/home/components/HomeMatchCard";
+import { HomeSectionLabel } from "@/ui/web/modules/home/components/HomeSectionLabel";
+import type { HomeMatch } from "@/ui/web/modules/home/components/home.types";
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const toOutcomeStatus = (game: Game, viewerSlot: PlayerSlot | null) => {
+  if (game.endedReason === "draw" || game.winner === null || !viewerSlot) {
+    return "stalemate" as const;
+  }
+  return game.winner === viewerSlot ? "victory" : "defeat";
+};
+
+const toModeLabel = (game: Game) => {
+  if (game.turnDurationMs !== null) {
+    return "Timed Challenge";
+  }
+  if (game.match.format === "bo3") {
+    return "Best of Three";
+  }
+  if (game.match.format === "bo5") {
+    return "Best of Five";
+  }
+  if (game.gridSize > 3) {
+    return "Tactical Grid Mode";
+  }
+  return "Classic Mode";
+};
+
+const toMatchTime = (timestamp: number) => {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(timestamp);
+};
+
+const resolveViewerSlot = (
+  game: Game,
+  currentUserId: string | undefined,
+): PlayerSlot | null => {
+  if (!currentUserId) {
+    return null;
+  }
+  if (game.p1UserId === currentUserId) {
+    return "P1";
+  }
+  return "P2";
+};
+
+const resolveOpponentUserId = (
+  game: Game,
+  currentUserId: string | undefined,
+) => {
+  if (!currentUserId) {
+    return game.p2UserId ?? game.p1UserId;
+  }
+  return game.p1UserId === currentUserId ? game.p2UserId : game.p1UserId;
+};
+
+type HomeMatchesProps = {
+  endedGames: Game[];
+};
+
+export const HomeMatches = ({ endedGames }: HomeMatchesProps) => {
+  const currentUser = useCurrentUser();
+  const currentUserId = currentUser?.id;
+  const now = Date.now();
+  const recentMatches: HomeMatch[] = [];
+  const previousWeekMatches: HomeMatch[] = [];
+
+  for (const game of endedGames) {
+    const viewerSlot = resolveViewerSlot(game, currentUserId);
+    const status = toOutcomeStatus(game, viewerSlot);
+    const match: HomeMatch = {
+      id: game.id,
+      status,
+      time: toMatchTime(game.updatedTime),
+      opponentUserId: resolveOpponentUserId(game, currentUserId),
+      subtitle: toModeLabel(game),
+    };
+
+    if (now - game.updatedTime <= WEEK_MS) {
+      recentMatches.push(match);
+      continue;
+    }
+    previousWeekMatches.push(match);
+  }
+
+  return (
+    <div className="flex flex-col gap-5 pr-2">
+      <HomeSectionLabel text="Recent Matches" />
+      <div className="space-y-5">
+        {recentMatches.map((match) => (
+          <HomeMatchCard key={match.id} {...match} />
+        ))}
+        <Activity
+          name={"recent-empty"}
+          mode={recentMatches.length === 0 ? "visible" : "hidden"}
+        >
+          <P className="mt-0! text-sm font-semibold text-muted-foreground">
+            No recent matches in the last 7 days.
+          </P>
+        </Activity>
+      </div>
+
+      <HomeSectionLabel text="Previous Week" />
+      <div className="space-y-5">
+        {previousWeekMatches.map((match) => (
+          <HomeMatchCard key={match.id} {...match} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/web/modules/home/components/HomeSectionLabel.tsx
+++ b/src/ui/web/modules/home/components/HomeSectionLabel.tsx
@@ -1,0 +1,17 @@
+import { Small } from "@/ui/web/components/Typography";
+
+type HomeSectionLabelProps = {
+  text: string;
+};
+
+export const HomeSectionLabel = ({ text }: HomeSectionLabelProps) => {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="h-px flex-1 bg-border/60" />
+      <Small variant="label" className="text-[10px] text-muted-foreground/80">
+        {text}
+      </Small>
+      <span className="h-px flex-1 bg-border/60" />
+    </div>
+  );
+};

--- a/src/ui/web/modules/home/components/HomeStatCard.tsx
+++ b/src/ui/web/modules/home/components/HomeStatCard.tsx
@@ -1,0 +1,45 @@
+import { Flame, Swords, Trophy } from "lucide-react";
+
+import { H4, Small } from "@/ui/web/components/Typography";
+import { Card, CardContent } from "@/ui/web/components/ui/card";
+import { cn } from "@/ui/web/lib/utils";
+import type { HomeStat } from "@/ui/web/modules/home/components/home.types";
+
+const iconByAccent = {
+  primary: Trophy,
+  opponent: Swords,
+  warning: Flame,
+} as const;
+
+export const HomeStatCard = ({ label, value, accent }: HomeStat) => {
+  const Icon = iconByAccent[accent];
+
+  return (
+    <Card
+      className={cn(
+        "min-w-34 flex-1 gap-0 rounded-3xl py-0 backdrop-blur-xs",
+        "shadow-[0_12px_28px_-24px_rgba(15,23,42,0.35)] dark:shadow-[0_20px_48px_-36px_rgba(0,0,0,0.8)]",
+      )}
+    >
+      <CardContent className="px-4 py-3">
+        <div className="mb-3 flex items-center gap-2">
+          <span
+            className={cn(
+              "grid size-5 place-items-center rounded-full",
+              accent === "primary" && "bg-primary/15 text-primary",
+              accent === "opponent" && "bg-opponent/15 text-opponent",
+              accent === "warning" && "bg-destructive/15 text-destructive",
+            )}
+          >
+            <Icon className="size-3" />
+          </span>
+          <Small variant="label" className="text-[10px] text-muted-foreground">
+            {label}
+          </Small>
+        </div>
+
+        <H4 className="text-3xl leading-none">{value}</H4>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/ui/web/modules/home/components/HomeStats.test.tsx
+++ b/src/ui/web/modules/home/components/HomeStats.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+
+import type { Game } from "@/domain/entities/Game";
+
+import { HomeStats } from "./HomeStats";
+
+const useCurrentUserMock = vi.fn();
+
+vi.mock("@/ui/web/hooks/useUser", () => ({
+  useCurrentUser: () => useCurrentUserMock(),
+}));
+
+vi.mock("@/ui/web/modules/home/components/HomeStatCard", () => ({
+  HomeStatCard: ({ label, value }: { label: string; value: string }) => (
+    <div>{`${label}:${value}`}</div>
+  ),
+}));
+
+const createGame = (overrides: Partial<Game>): Game => {
+  const now = Date.now();
+  return {
+    id: "game-id",
+    status: "ended",
+    board: [],
+    gridSize: 3,
+    winLength: 3,
+    match: {
+      format: "single",
+      targetWins: 1,
+      roundIndex: 1,
+      score: { P1: 0, P2: 0 },
+      matchWinner: null,
+      rounds: [],
+    },
+    p1UserId: "u1",
+    p2UserId: "u2",
+    currentTurn: "P1",
+    turnDurationMs: null,
+    turnDeadlineTime: null,
+    winner: null,
+    winningLine: null,
+    endedReason: "draw",
+    endedTime: now,
+    pausedTime: null,
+    abandonedBy: null,
+    presence: { P1: { lastSeenTime: now }, P2: { lastSeenTime: now } },
+    movesCount: 0,
+    version: 1,
+    lastMove: null,
+    updatedTime: now,
+    ...overrides,
+  };
+};
+
+describe("HomeStats", () => {
+  it("returns zeroed stats when current user is not available", () => {
+    useCurrentUserMock.mockReturnValue(null);
+
+    render(
+      <HomeStats
+        endedGames={[
+          createGame({ winner: "P1", endedReason: "win" }),
+          createGame({ winner: "P2", endedReason: "win" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Wins:0")).toBeInTheDocument();
+    expect(screen.getByText("Win Rate:0%")).toBeInTheDocument();
+    expect(screen.getByText("Streak:0")).toBeInTheDocument();
+  });
+
+  it("computes wins/win-rate and stops streak on first non-win", () => {
+    useCurrentUserMock.mockReturnValue({ id: "u1" });
+
+    render(
+      <HomeStats
+        endedGames={[
+          createGame({
+            id: "g1",
+            p1UserId: "u1",
+            winner: "P2",
+            endedReason: "win",
+          }),
+          createGame({
+            id: "g2",
+            p1UserId: "u1",
+            winner: "P1",
+            endedReason: "win",
+          }),
+          createGame({
+            id: "g3",
+            p1UserId: "u1",
+            winner: "P1",
+            endedReason: "win",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Wins:2")).toBeInTheDocument();
+    expect(screen.getByText("Win Rate:67%")).toBeInTheDocument();
+    expect(screen.getByText("Streak:0")).toBeInTheDocument();
+  });
+
+  it("increments streak for consecutive leading wins", () => {
+    useCurrentUserMock.mockReturnValue({ id: "u1" });
+
+    render(
+      <HomeStats
+        endedGames={[
+          createGame({
+            id: "g1",
+            p1UserId: "u1",
+            winner: "P1",
+            endedReason: "win",
+          }),
+          createGame({
+            id: "g2",
+            p1UserId: "u1",
+            winner: "P1",
+            endedReason: "win",
+          }),
+          createGame({
+            id: "g3",
+            p1UserId: "u1",
+            winner: "P2",
+            endedReason: "win",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Wins:2")).toBeInTheDocument();
+    expect(screen.getByText("Streak:2")).toBeInTheDocument();
+  });
+});

--- a/src/ui/web/modules/home/components/HomeStats.tsx
+++ b/src/ui/web/modules/home/components/HomeStats.tsx
@@ -1,0 +1,66 @@
+import type { Game, PlayerSlot } from "@/domain/entities/Game";
+import { ScrollArea, ScrollBar } from "@/ui/web/components/ui/scroll-area";
+import { useCurrentUser } from "@/ui/web/hooks/useUser";
+import { HomeStatCard } from "@/ui/web/modules/home/components/HomeStatCard";
+import type { HomeStat } from "@/ui/web/modules/home/components/home.types";
+
+type HomeStatsProps = {
+  endedGames: Game[];
+};
+
+export const HomeStats = ({ endedGames }: HomeStatsProps) => {
+  const currentUser = useCurrentUser();
+  const currentUserId = currentUser?.id;
+  const wins = endedGames.filter((game) => {
+    if (!currentUserId) {
+      return false;
+    }
+    const viewerSlot: PlayerSlot =
+      game.p1UserId === currentUserId ? "P1" : "P2";
+    return game.winner === viewerSlot;
+  }).length;
+  const total = endedGames.length;
+  const winRate = total > 0 ? Math.round((wins / total) * 100) : 0;
+
+  let streak = 0;
+  for (const game of endedGames) {
+    if (!currentUserId) {
+      break;
+    }
+    const viewerSlot: PlayerSlot =
+      game.p1UserId === currentUserId ? "P1" : "P2";
+    if (game.winner !== viewerSlot) {
+      break;
+    }
+    streak += 1;
+  }
+
+  const stats: HomeStat[] = [
+    { id: "wins", label: "Wins", value: String(wins), accent: "primary" },
+    {
+      id: "win-rate",
+      label: "Win Rate",
+      value: `${winRate}%`,
+      accent: "opponent",
+    },
+    {
+      id: "streak",
+      label: "Streak",
+      value: String(streak),
+      accent: "warning",
+    },
+  ];
+
+  return (
+    <ScrollArea>
+      <div className="flex gap-4 overflow-x-auto py-3">
+        {stats.map((stat) => (
+          <div className="snap-center" key={stat.id}>
+            <HomeStatCard {...stat} />
+          </div>
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+};

--- a/src/ui/web/modules/home/components/HomeStats.tsx
+++ b/src/ui/web/modules/home/components/HomeStats.tsx
@@ -53,7 +53,7 @@ export const HomeStats = ({ endedGames }: HomeStatsProps) => {
 
   return (
     <ScrollArea>
-      <div className="flex gap-4 overflow-x-auto py-3">
+      <div className="flex gap-4 overflow-x-auto py-3 px-1">
         {stats.map((stat) => (
           <div className="snap-center" key={stat.id}>
             <HomeStatCard {...stat} />

--- a/src/ui/web/modules/home/components/home.types.ts
+++ b/src/ui/web/modules/home/components/home.types.ts
@@ -11,7 +11,6 @@ export type HomeMatch = {
   id: string;
   status: HomeMatchStatus;
   time: string;
-  title: string;
+  opponentUserId: string | null;
   subtitle: string;
-  opponentInitials: string;
 };

--- a/src/ui/web/modules/home/components/home.types.ts
+++ b/src/ui/web/modules/home/components/home.types.ts
@@ -1,0 +1,17 @@
+export type HomeStat = {
+  id: string;
+  label: string;
+  value: string;
+  accent: "primary" | "opponent" | "warning";
+};
+
+export type HomeMatchStatus = "victory" | "defeat" | "stalemate";
+
+export type HomeMatch = {
+  id: string;
+  status: HomeMatchStatus;
+  time: string;
+  title: string;
+  subtitle: string;
+  opponentInitials: string;
+};

--- a/src/ui/web/modules/home/screens/HomeScreen.test.tsx
+++ b/src/ui/web/modules/home/screens/HomeScreen.test.tsx
@@ -4,6 +4,7 @@ import { HomeScreen } from "./HomeScreen";
 
 const useRecentGamesQueryMock = vi.fn();
 const useCurrentUserMock = vi.fn();
+const useUserByIdMock = vi.fn();
 
 vi.mock("@/infrastructure/convex/GameApi", () => ({
   useRecentGamesQuery: () => useRecentGamesQueryMock(),
@@ -11,11 +12,26 @@ vi.mock("@/infrastructure/convex/GameApi", () => ({
 
 vi.mock("@/ui/web/hooks/useUser", () => ({
   useCurrentUser: () => useCurrentUserMock(),
+  useUserById: (userId?: string | null) => useUserByIdMock(userId),
 }));
 
 describe("HomeScreen", () => {
   beforeEach(() => {
-    useCurrentUserMock.mockReturnValue({ id: "user-1" });
+    useCurrentUserMock.mockReturnValue({
+      id: "user-1",
+      username: "you",
+      avatar: { type: "preset", value: "avatar-1" },
+    });
+    useUserByIdMock.mockImplementation((userId?: string | null) => {
+      if (!userId) {
+        return null;
+      }
+      return {
+        id: userId,
+        username: `player-${userId.slice(-1)}`,
+        avatar: { type: "preset", value: "avatar-2" },
+      };
+    });
   });
 
   it("renders the match history dashboard layout", () => {

--- a/src/ui/web/modules/home/screens/HomeScreen.test.tsx
+++ b/src/ui/web/modules/home/screens/HomeScreen.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+
+import { HomeScreen } from "./HomeScreen";
+
+describe("HomeScreen", () => {
+  it("renders the match history dashboard layout", () => {
+    render(<HomeScreen />);
+
+    expect(screen.getByText(/mission logs/i)).toBeInTheDocument();
+    expect(screen.getByText(/match history/i)).toBeInTheDocument();
+    expect(screen.getByText(/recent matches/i)).toBeInTheDocument();
+    expect(screen.getByText(/previous week/i)).toBeInTheDocument();
+  });
+
+  it("renders stat cards and match cards", () => {
+    render(<HomeScreen />);
+
+    expect(screen.getByText("Wins")).toBeInTheDocument();
+    expect(screen.getByText("Win Rate")).toBeInTheDocument();
+    expect(screen.getByText("Streak")).toBeInTheDocument();
+    expect(screen.getByText(/vs CPU \(Hard\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/vs Cyber_Samurai/i)).toBeInTheDocument();
+    expect(screen.getByText(/vs Player_Two/i)).toBeInTheDocument();
+  });
+});

--- a/src/ui/web/modules/home/screens/HomeScreen.test.tsx
+++ b/src/ui/web/modules/home/screens/HomeScreen.test.tsx
@@ -2,24 +2,108 @@ import { render, screen } from "@testing-library/react";
 
 import { HomeScreen } from "./HomeScreen";
 
+const useRecentGamesQueryMock = vi.fn();
+const useCurrentUserMock = vi.fn();
+
+vi.mock("@/infrastructure/convex/GameApi", () => ({
+  useRecentGamesQuery: () => useRecentGamesQueryMock(),
+}));
+
+vi.mock("@/ui/web/hooks/useUser", () => ({
+  useCurrentUser: () => useCurrentUserMock(),
+}));
+
 describe("HomeScreen", () => {
+  beforeEach(() => {
+    useCurrentUserMock.mockReturnValue({ id: "user-1" });
+  });
+
   it("renders the match history dashboard layout", () => {
+    useRecentGamesQueryMock.mockReturnValue([]);
     render(<HomeScreen />);
 
     expect(screen.getByText(/mission logs/i)).toBeInTheDocument();
     expect(screen.getByText(/match history/i)).toBeInTheDocument();
-    expect(screen.getByText(/recent matches/i)).toBeInTheDocument();
-    expect(screen.getByText(/previous week/i)).toBeInTheDocument();
+    expect(screen.getByText(/^recent matches$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^previous week$/i)).toBeInTheDocument();
   });
 
-  it("renders stat cards and match cards", () => {
+  it("renders stat cards and match cards from recent games data", () => {
+    const now = Date.now();
+    useRecentGamesQueryMock.mockReturnValue([
+      {
+        id: "game-1",
+        status: "ended",
+        board: [],
+        gridSize: 3,
+        winLength: 3,
+        match: {
+          format: "single",
+          targetWins: 1,
+          roundIndex: 1,
+          score: { P1: 1, P2: 0 },
+          matchWinner: "P1",
+          rounds: [],
+        },
+        p1UserId: "user-1",
+        p2UserId: "user-2",
+        currentTurn: "P1",
+        turnDurationMs: null,
+        turnDeadlineTime: null,
+        winner: "P1",
+        winningLine: null,
+        endedReason: "win",
+        endedTime: now,
+        pausedTime: null,
+        abandonedBy: null,
+        presence: { P1: { lastSeenTime: now }, P2: { lastSeenTime: now } },
+        movesCount: 5,
+        version: 1,
+        lastMove: null,
+        updatedTime: now,
+      },
+      {
+        id: "game-2",
+        status: "ended",
+        board: [],
+        gridSize: 3,
+        winLength: 3,
+        match: {
+          format: "single",
+          targetWins: 1,
+          roundIndex: 1,
+          score: { P1: 0, P2: 1 },
+          matchWinner: "P2",
+          rounds: [],
+        },
+        p1UserId: "user-2",
+        p2UserId: "user-1",
+        currentTurn: "P2",
+        turnDurationMs: null,
+        turnDeadlineTime: null,
+        winner: "P2",
+        winningLine: null,
+        endedReason: "win",
+        endedTime: now,
+        pausedTime: null,
+        abandonedBy: null,
+        presence: { P1: { lastSeenTime: now }, P2: { lastSeenTime: now } },
+        movesCount: 6,
+        version: 1,
+        lastMove: null,
+        updatedTime: now - 2 * 24 * 60 * 60 * 1000,
+      },
+    ]);
+
     render(<HomeScreen />);
 
     expect(screen.getByText("Wins")).toBeInTheDocument();
     expect(screen.getByText("Win Rate")).toBeInTheDocument();
     expect(screen.getByText("Streak")).toBeInTheDocument();
-    expect(screen.getByText(/vs CPU \(Hard\)/i)).toBeInTheDocument();
-    expect(screen.getByText(/vs Cyber_Samurai/i)).toBeInTheDocument();
-    expect(screen.getByText(/vs Player_Two/i)).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getAllByText(/vs player/i)).toHaveLength(2);
+    expect(
+      screen.getByText(/no recent matches in the last 7 days/i),
+    ).not.toBeVisible();
   });
 });

--- a/src/ui/web/modules/home/screens/HomeScreen.tsx
+++ b/src/ui/web/modules/home/screens/HomeScreen.tsx
@@ -1,114 +1,14 @@
-import { Activity } from "react";
-
 import { ScrollText } from "lucide-react";
 
-import type { Game, PlayerSlot } from "@/domain/entities/Game";
 import { useRecentGamesQuery } from "@/infrastructure/convex/GameApi";
 import { Header } from "@/ui/web/components/Header";
 import { P } from "@/ui/web/components/Typography";
-import { useCurrentUser } from "@/ui/web/hooks/useUser";
-import { HomeMatchCard } from "@/ui/web/modules/home/components/HomeMatchCard";
-import { HomeSectionLabel } from "@/ui/web/modules/home/components/HomeSectionLabel";
+import { HomeMatches } from "@/ui/web/modules/home/components/HomeMatches";
 import { HomeStats } from "@/ui/web/modules/home/components/HomeStats";
-import type { HomeMatch } from "@/ui/web/modules/home/components/home.types";
-
-const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-
-const toOutcomeStatus = (game: Game, viewerSlot: PlayerSlot | null) => {
-  if (game.endedReason === "draw" || game.winner === null || !viewerSlot) {
-    return "stalemate" as const;
-  }
-  return game.winner === viewerSlot ? "victory" : "defeat";
-};
-
-const toOpponentName = (game: Game, currentUserId: string | undefined) => {
-  if (!currentUserId) {
-    return "Opponent";
-  }
-  const opponentId =
-    game.p1UserId === currentUserId ? game.p2UserId : game.p1UserId;
-  if (!opponentId) {
-    return "Open Slot";
-  }
-  return `Player ${opponentId.slice(-4).toUpperCase()}`;
-};
-
-const toOpponentInitials = (name: string) => {
-  const chunks = name.split(" ").filter(Boolean);
-  if (chunks.length === 1) {
-    return chunks[0].slice(0, 2).toUpperCase();
-  }
-  return `${chunks[0][0] ?? ""}${chunks[1][0] ?? ""}`.toUpperCase();
-};
-
-const toModeLabel = (game: Game) => {
-  if (game.turnDurationMs !== null) {
-    return "Timed Challenge";
-  }
-  if (game.match.format === "bo3") {
-    return "Best of Three";
-  }
-  if (game.match.format === "bo5") {
-    return "Best of Five";
-  }
-  if (game.gridSize > 3) {
-    return "Tactical Grid Mode";
-  }
-  return "Classic Mode";
-};
-
-const toMatchTime = (timestamp: number) => {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(timestamp);
-};
-
-const resolveViewerSlot = (
-  game: Game,
-  currentUserId: string | undefined,
-): PlayerSlot | null => {
-  if (!currentUserId) {
-    return null;
-  }
-  if (game.p1UserId === currentUserId) {
-    return "P1";
-  }
-  return "P2";
-};
 
 export function HomeScreen() {
-  const currentUser = useCurrentUser();
   const recentGames = useRecentGamesQuery();
-
   const endedGames = recentGames ?? [];
-  const currentUserId = currentUser?.id;
-  const now = Date.now();
-  const recentMatches: HomeMatch[] = [];
-  const previousWeekMatches: HomeMatch[] = [];
-
-  for (const game of endedGames) {
-    const viewerSlot = resolveViewerSlot(game, currentUserId);
-    const status = toOutcomeStatus(game, viewerSlot);
-    const opponentName = toOpponentName(game, currentUserId);
-    const match: HomeMatch = {
-      id: game.id,
-      status,
-      time: toMatchTime(game.updatedTime),
-      title: opponentName,
-      subtitle: toModeLabel(game),
-      opponentInitials: toOpponentInitials(opponentName),
-    };
-
-    if (now - game.updatedTime <= WEEK_MS) {
-      recentMatches.push(match);
-      continue;
-    }
-    previousWeekMatches.push(match);
-  }
 
   return (
     <section className="mx-auto flex max-w-[calc(100svw-2rem)] w-full h-full md:max-w-xl flex-col gap-10 pb-12">
@@ -116,29 +16,7 @@ export function HomeScreen() {
 
       <HomeStats endedGames={endedGames} />
 
-      <div className="flex flex-col gap-5 pr-2">
-        <HomeSectionLabel text="Recent Matches" />
-        <div className="space-y-5">
-          {recentMatches.map((match) => (
-            <HomeMatchCard key={match.id} {...match} />
-          ))}
-          <Activity
-            name={"recent-empty"}
-            mode={recentMatches.length === 0 ? "visible" : "hidden"}
-          >
-            <P className="mt-0! text-sm font-semibold text-muted-foreground">
-              No recent matches in the last 7 days.
-            </P>
-          </Activity>
-        </div>
-
-        <HomeSectionLabel text="Previous Week" />
-        <div className="space-y-5">
-          {previousWeekMatches.map((match) => (
-            <HomeMatchCard key={match.id} {...match} />
-          ))}
-        </div>
-      </div>
+      <HomeMatches endedGames={endedGames} />
 
       <div className={"flex flex-col items-center justify-center gap-2"}>
         <div className="flex size-14 items-center justify-center rounded-full border bg-card">

--- a/src/ui/web/modules/home/screens/HomeScreen.tsx
+++ b/src/ui/web/modules/home/screens/HomeScreen.tsx
@@ -1,16 +1,100 @@
 import { ScrollText } from "lucide-react";
 
+import { Header } from "@/ui/web/components/Header";
 import { P } from "@/ui/web/components/Typography";
+import { ScrollArea, ScrollBar } from "@/ui/web/components/ui/scroll-area";
+import { HomeMatchCard } from "@/ui/web/modules/home/components/HomeMatchCard";
+import { HomeSectionLabel } from "@/ui/web/modules/home/components/HomeSectionLabel";
+import { HomeStatCard } from "@/ui/web/modules/home/components/HomeStatCard";
+import type {
+  HomeMatch,
+  HomeStat,
+} from "@/ui/web/modules/home/components/home.types";
+
+const homeStats: HomeStat[] = [
+  { id: "wins", label: "Wins", value: "42", accent: "primary" },
+  { id: "win-rate", label: "Win Rate", value: "68%", accent: "opponent" },
+  { id: "streak", label: "Streak", value: "5", accent: "warning" },
+];
+
+const recentMatches: HomeMatch[] = [
+  {
+    id: "recent-1",
+    status: "victory",
+    time: "14:02",
+    title: "CPU (Hard)",
+    subtitle: "Tactical Grid Mode",
+    opponentInitials: "CP",
+  },
+  {
+    id: "recent-2",
+    status: "defeat",
+    time: "09:15",
+    title: "Cyber_Samurai",
+    subtitle: "Classic Mode",
+    opponentInitials: "CS",
+  },
+  {
+    id: "recent-3",
+    status: "stalemate",
+    time: "Oct 22 · 18:45",
+    title: "CPU (Medium)",
+    subtitle: "Timed Challenge",
+    opponentInitials: "CP",
+  },
+];
+
+const previousWeekMatches: HomeMatch[] = [
+  {
+    id: "week-1",
+    status: "victory",
+    time: "Oct 18",
+    title: "Player_Two",
+    subtitle: "Tactical Grid Mode",
+    opponentInitials: "PT",
+  },
+];
 
 export function HomeScreen() {
   return (
-    <div className="flex h-svh flex-col items-center justify-center gap-4 text-center no-offset">
-      <div className="flex size-20 items-center justify-center rounded-full border bg-card">
-        <ScrollText className="size-10 text-foreground/80" />
+    <section className="mx-auto flex max-w-[calc(100svw-2rem)] w-full h-full md:max-w-xl flex-col gap-10 pb-12">
+      <Header title="Match History" eyebrow="Mission Logs" />
+
+      <ScrollArea>
+        <div className="flex gap-4 overflow-x-auto py-3">
+          {homeStats.map((stat) => (
+            <div className="snap-center" key={stat.id}>
+              <HomeStatCard {...stat} />
+            </div>
+          ))}
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+
+      <div className="flex flex-col gap-5 pr-2">
+        <HomeSectionLabel text="Recent Matches" />
+        <div className="space-y-5">
+          {recentMatches.map((match) => (
+            <HomeMatchCard key={match.id} {...match} />
+          ))}
+        </div>
+
+        <HomeSectionLabel text="Previous Week" />
+        <div className="space-y-5">
+          {previousWeekMatches.map((match) => (
+            <HomeMatchCard key={match.id} {...match} />
+          ))}
+        </div>
       </div>
-      <P className="text-lg font-semibold text-muted-foreground">
-        No more logs found
-      </P>
-    </div>
+
+      <div className={"flex flex-col items-center justify-center gap-2"}>
+        <div className="flex size-14 items-center justify-center rounded-full border bg-card">
+          <ScrollText className="size-8 text-foreground/80" />
+        </div>
+        <P className="text-md font-semibold text-muted-foreground mt-0!">
+          No more logs found
+        </P>
+      </div>
+    </section>
   );
 }

--- a/src/ui/web/modules/play/screens/PlayScreen.test.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.test.tsx
@@ -65,10 +65,12 @@ describe("PlayScreen", () => {
   });
 
   it("prevents duplicate submissions while creating a game", async () => {
-    let resolveCall: ((value: string) => void) | null = null;
+    let resolveCall: (value: string) => void = () => {
+      throw new Error("resolveCall not initialized");
+    };
     vi.mocked(findOrCreateGameUseCase).mockImplementation(
       () =>
-        new Promise((resolve) => {
+        new Promise<string>((resolve) => {
           resolveCall = resolve;
         }),
     );
@@ -90,7 +92,7 @@ describe("PlayScreen", () => {
     invokeReactClick(classicModeButton);
     expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
 
-    resolveCall?.("game-999");
+    resolveCall("game-999");
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith({
         to: "/match",

--- a/src/ui/web/modules/play/screens/PlayScreen.test.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
+import { gameRepository } from "@/infrastructure/convex/repository/gameRepository";
+
+import { PlayScreen } from "./PlayScreen";
+
+const navigateMock = vi.fn();
+
+const invokeReactClick = (element: HTMLElement) => {
+  const propsKey = Object.keys(element).find((key) =>
+    key.startsWith("__reactProps$"),
+  );
+  if (!propsKey) {
+    throw new Error("React props key not found");
+  }
+  const reactProps = (
+    element as unknown as Record<string, { onClick?: () => void }>
+  )[propsKey];
+  reactProps.onClick?.();
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/application/games/findOrCreateGameUseCase", () => ({
+  findOrCreateGameUseCase: vi.fn(),
+}));
+
+describe("PlayScreen", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.mocked(findOrCreateGameUseCase).mockReset();
+  });
+
+  it("renders all game modes", () => {
+    render(<PlayScreen />);
+
+    expect(screen.getByText("Classic Mode")).toBeInTheDocument();
+    expect(screen.getByText("Best of Three")).toBeInTheDocument();
+    expect(screen.getByText("Best of Five")).toBeInTheDocument();
+    expect(screen.getByText("Time Challenge")).toBeInTheDocument();
+    expect(screen.getByText("4x4 Grid")).toBeInTheDocument();
+    expect(screen.getByText("6x6 Grid")).toBeInTheDocument();
+  });
+
+  it("creates and navigates to match when selecting a mode", async () => {
+    vi.mocked(findOrCreateGameUseCase).mockResolvedValue("game-123");
+    render(<PlayScreen />);
+
+    fireEvent.click(screen.getByRole("button", { name: /classic mode/i }));
+
+    await waitFor(() => {
+      expect(findOrCreateGameUseCase).toHaveBeenCalledWith(gameRepository, {
+        gridSize: 3,
+        winLength: 3,
+        matchFormat: "single",
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/match",
+      search: { gameId: "game-123" },
+    });
+  });
+
+  it("prevents duplicate submissions while creating a game", async () => {
+    let resolveCall: ((value: string) => void) | null = null;
+    vi.mocked(findOrCreateGameUseCase).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCall = resolve;
+        }),
+    );
+    render(<PlayScreen />);
+
+    const classicModeButton = screen.getByRole("button", {
+      name: /classic mode/i,
+    });
+    fireEvent.click(classicModeButton);
+
+    await waitFor(() => {
+      expect(classicModeButton).toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /best of three/i }));
+
+    expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
+
+    invokeReactClick(classicModeButton);
+    expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
+
+    resolveCall?.("game-999");
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: "/match",
+        search: { gameId: "game-999" },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Design the home screen to provide a quick, useful snapshot of player activity and progress.

## Scope
- User statistics section (core performance/activity metrics)
- Recent matches section
- Previous week matches section
- Missions section (including completion/progress cues)
- Logs/timeline section (recent activity events)

## Notes
- Focus this issue on the screen design definition (information architecture, section hierarchy, and visual direction).
- Include clear states for empty/loading/error where needed.

## Acceptance Criteria
- Home screen layout and section hierarchy are defined
- Each section has clear data intent and UX state expectations
- Mission/log presentation supports quick progress scanning

Closes #77