### PR TITLE
[GHI#99] Port PlayScreen from web to mobile

### DIFF
--- a/mobile/__mocks__/expo-router.ts
+++ b/mobile/__mocks__/expo-router.ts
@@ -3,10 +3,12 @@ import { View } from "react-native";
 
 export const router = {
   back: jest.fn(),
+  push: jest.fn(),
   replace: jest.fn(),
 };
 
 export const usePathname = jest.fn(() => "/");
+export const useLocalSearchParams = jest.fn(() => ({}));
 
 export const Redirect = ({ href }: { href: string }) =>
   createElement(View, {

--- a/src/ui/mobile/layout/components/NavBar.test.tsx
+++ b/src/ui/mobile/layout/components/NavBar.test.tsx
@@ -36,7 +36,7 @@ describe("NavBar", () => {
 
     fireEvent.press(screen.getByText("Play"));
 
-    expect(router.replace).toHaveBeenCalledWith("/mock");
+    expect(router.replace).toHaveBeenCalledWith("/play");
   });
 
   it("renders the android navigation shell", () => {

--- a/src/ui/mobile/layout/components/NavBar.tsx
+++ b/src/ui/mobile/layout/components/NavBar.tsx
@@ -23,7 +23,7 @@ const navItems: NavItem[] = [
   {
     icon: Gamepad2,
     label: "Play",
-    path: "/mock",
+    path: "/play",
   },
   {
     icon: Settings,

--- a/src/ui/mobile/modules/play/screens/PlayScreen.test.tsx
+++ b/src/ui/mobile/modules/play/screens/PlayScreen.test.tsx
@@ -1,0 +1,88 @@
+import { router } from "expo-router";
+
+import { fireEvent, waitFor } from "@testing-library/react-native";
+
+import { renderMobile } from "@/test/mobile/render";
+import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
+
+import { PlayScreen } from "./PlayScreen";
+
+const mockSetHeader = jest.fn();
+const mockCreateGame = jest.fn();
+
+jest.mock("@/ui/mobile/application/providers/MobileHeaderProvider", () => ({
+  useMobileHeader: () => ({
+    setHeader: mockSetHeader,
+  }),
+}));
+
+jest.mock("@/ui/shared/play/hooks/useCreateGame", () => ({
+  useCreateGame: jest.fn(),
+}));
+
+describe("PlayScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useCreateGame).mockReturnValue({
+      createGame: mockCreateGame,
+      isCreating: false,
+    });
+  });
+
+  it("sets the header and renders the shared play catalog", () => {
+    const screen = renderMobile(<PlayScreen />);
+
+    expect(mockSetHeader).toHaveBeenCalledWith({
+      title: "Select Mode",
+      eyebrow: "New Game",
+    });
+    expect(screen.getByText("Classic Mode")).toBeTruthy();
+    expect(screen.getByText("Best of Three")).toBeTruthy();
+    expect(screen.getByText("Best of Five")).toBeTruthy();
+    expect(screen.getByText("Time Challenge")).toBeTruthy();
+    expect(screen.getByText("4x4 Grid")).toBeTruthy();
+    expect(screen.getByText("6x6 Grid")).toBeTruthy();
+  });
+
+  it("creates a game and navigates to the mobile match route", async () => {
+    mockCreateGame.mockResolvedValue("game-123");
+
+    const screen = renderMobile(<PlayScreen />);
+
+    fireEvent.press(screen.getByLabelText("Classic Mode"));
+
+    await waitFor(() => {
+      expect(mockCreateGame).toHaveBeenCalledWith({
+        gridSize: 3,
+        winLength: 3,
+        matchFormat: "single",
+      });
+    });
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: "/match",
+      params: { gameId: "game-123" },
+    });
+  });
+
+  it("does not start another selection while the shared flow is busy", () => {
+    jest.mocked(useCreateGame).mockReturnValue({
+      createGame: mockCreateGame,
+      isCreating: true,
+    });
+
+    const screen = renderMobile(<PlayScreen />);
+
+    fireEvent.press(screen.getByLabelText("Classic Mode"));
+
+    expect(mockCreateGame).not.toHaveBeenCalled();
+  });
+
+  it("clears the header on unmount", () => {
+    const screen = renderMobile(<PlayScreen />);
+
+    screen.unmount();
+
+    expect(mockSetHeader).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/src/ui/mobile/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/mobile/modules/play/screens/PlayScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { router } from "expo-router";
 import type { LucideIcon } from "lucide-react-native";
@@ -11,7 +11,7 @@ import {
   Medal,
   Trophy,
 } from "lucide-react-native";
-import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { useMobileHeader } from "@/ui/mobile/application/providers/MobileHeaderProvider";
 import { H3, H6, Muted } from "@/ui/mobile/components/Typography";
@@ -24,6 +24,7 @@ import {
   type PlayMode,
 } from "@/ui/shared/play/constants/modes";
 import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
+import { playModeStyles } from "@/ui/shared/play/style/playModeStyles";
 
 const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
   hash: Hash,
@@ -34,46 +35,9 @@ const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
   "grid-6": Grid3x3,
 };
 
-const modeStyles: Record<
-  PlayMode["tone"],
-  { badge: string; badgeIcon: string; halo: string }
-> = {
-  emerald: {
-    badge: "bg-emerald-500/10",
-    badgeIcon: "text-emerald-500",
-    halo: "bg-emerald-500/10",
-  },
-  yellow: {
-    badge: "bg-yellow-500/10",
-    badgeIcon: "text-yellow-500",
-    halo: "bg-yellow-500/10",
-  },
-  fuchsia: {
-    badge: "bg-fuchsia-500/10",
-    badgeIcon: "text-fuchsia-500",
-    halo: "bg-fuchsia-500/10",
-  },
-  orange: {
-    badge: "bg-orange-500/10",
-    badgeIcon: "text-orange-500",
-    halo: "bg-orange-500/10",
-  },
-  sky: {
-    badge: "bg-sky-500/10",
-    badgeIcon: "text-sky-500",
-    halo: "bg-sky-500/10",
-  },
-  violet: {
-    badge: "bg-violet-500/10",
-    badgeIcon: "text-violet-500",
-    halo: "bg-violet-500/10",
-  },
-};
-
 export const PlayScreen = () => {
   const { setHeader } = useMobileHeader();
   const { createGame, isCreating } = useCreateGame();
-  const [pendingModeId, setPendingModeId] = useState<string | null>(null);
 
   useEffect(() => {
     setHeader({
@@ -87,22 +51,16 @@ export const PlayScreen = () => {
   }, [setHeader]);
 
   const handleSelectMode = async (mode: PlayMode) => {
-    setPendingModeId(mode.id);
+    const gameId = await createGame(mode.config);
 
-    try {
-      const gameId = await createGame(mode.config);
-
-      if (!gameId) {
-        return;
-      }
-
-      router.push({
-        pathname: "/match",
-        params: { gameId },
-      });
-    } finally {
-      setPendingModeId(null);
+    if (!gameId) {
+      return;
     }
+
+    router.push({
+      pathname: "/match",
+      params: { gameId },
+    });
   };
 
   return (
@@ -117,21 +75,17 @@ export const PlayScreen = () => {
       <View className="gap-4">
         {PLAY_MODES.map((mode) => {
           const IconComponent = modeIcons[mode.icon];
-          const styles = modeStyles[mode.tone];
-          const isPending = pendingModeId === mode.id;
+          const styles = playModeStyles[mode.tone].mobile;
 
           return (
             <Card
               key={mode.id}
-              className={cn(
-                "gap-0 overflow-hidden rounded-4xl border-border/60 py-0",
-                isPending && styles.halo,
-              )}
+              className="gap-0 overflow-hidden rounded-4xl border-border/60 py-0"
             >
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={mode.title}
-                className={cn("active:bg-card/80", isCreating && "opacity-70")}
+                className={cn(styles.pressHalo, isCreating && "opacity-70")}
                 disabled={isCreating}
                 onPress={() => handleSelectMode(mode)}
               >
@@ -139,12 +93,12 @@ export const PlayScreen = () => {
                   <View
                     className={cn(
                       "size-10 items-center justify-center rounded-xl",
-                      styles.badge,
+                      styles.background,
                     )}
                   >
                     <Icon
                       as={IconComponent}
-                      className={cn("size-4", styles.badgeIcon)}
+                      className={cn("size-4", styles.iconColor)}
                     />
                   </View>
                   <View className="min-w-0 flex-1 items-center justify-center gap-1">
@@ -156,14 +110,10 @@ export const PlayScreen = () => {
                     </Muted>
                   </View>
                   <View className="size-5 items-center justify-center">
-                    {isPending ? (
-                      <ActivityIndicator style={stylesheets.spinner} />
-                    ) : (
-                      <Icon
-                        as={ChevronRight}
-                        className="size-5 text-muted-foreground"
-                      />
-                    )}
+                    <Icon
+                      as={ChevronRight}
+                      className="size-5 text-muted-foreground"
+                    />
                   </View>
                 </CardContent>
               </Pressable>
@@ -174,10 +124,3 @@ export const PlayScreen = () => {
     </View>
   );
 };
-
-const stylesheets = StyleSheet.create({
-  spinner: {
-    height: 20,
-    width: 20,
-  },
-});

--- a/src/ui/mobile/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/mobile/modules/play/screens/PlayScreen.tsx
@@ -14,11 +14,15 @@ import {
 import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
 
 import { useMobileHeader } from "@/ui/mobile/application/providers/MobileHeaderProvider";
-import { H3, H6, Muted, Small } from "@/ui/mobile/components/Typography";
+import { H3, H6, Muted } from "@/ui/mobile/components/Typography";
 import { Card, CardContent } from "@/ui/mobile/components/ui/card";
 import { Icon } from "@/ui/mobile/components/ui/icon";
 import { cn } from "@/ui/mobile/lib/utils";
-import { PLAY_MODES, type PlayMode } from "@/ui/shared/play/constants/modes";
+import {
+  PLAY_MODES,
+  PLAY_SCREEN_CONTENT,
+  type PlayMode,
+} from "@/ui/shared/play/constants/modes";
 import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
 
 const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
@@ -35,32 +39,32 @@ const modeStyles: Record<
   { badge: string; badgeIcon: string; halo: string }
 > = {
   emerald: {
-    badge: "border-emerald-500/20 bg-emerald-500/10",
+    badge: "bg-emerald-500/10",
     badgeIcon: "text-emerald-500",
     halo: "bg-emerald-500/10",
   },
   yellow: {
-    badge: "border-yellow-500/20 bg-yellow-500/10",
+    badge: "bg-yellow-500/10",
     badgeIcon: "text-yellow-500",
     halo: "bg-yellow-500/10",
   },
   fuchsia: {
-    badge: "border-fuchsia-500/20 bg-fuchsia-500/10",
+    badge: "bg-fuchsia-500/10",
     badgeIcon: "text-fuchsia-500",
     halo: "bg-fuchsia-500/10",
   },
   orange: {
-    badge: "border-orange-500/20 bg-orange-500/10",
+    badge: "bg-orange-500/10",
     badgeIcon: "text-orange-500",
     halo: "bg-orange-500/10",
   },
   sky: {
-    badge: "border-sky-500/20 bg-sky-500/10",
+    badge: "bg-sky-500/10",
     badgeIcon: "text-sky-500",
     halo: "bg-sky-500/10",
   },
   violet: {
-    badge: "border-violet-500/20 bg-violet-500/10",
+    badge: "bg-violet-500/10",
     badgeIcon: "text-violet-500",
     halo: "bg-violet-500/10",
   },
@@ -73,8 +77,8 @@ export const PlayScreen = () => {
 
   useEffect(() => {
     setHeader({
-      title: "Select Mode",
-      eyebrow: "New Game",
+      title: PLAY_SCREEN_CONTENT.title,
+      eyebrow: PLAY_SCREEN_CONTENT.eyebrow,
     });
 
     return () => {
@@ -103,22 +107,11 @@ export const PlayScreen = () => {
 
   return (
     <View className="flex-1 gap-8 pb-12">
-      <View className="gap-4 pt-2">
-        <Small
-          variant="label"
-          className="w-fit rounded-full border border-border/60 bg-card px-3 py-2 text-[10px] text-primary"
-        >
-          Fresh Match
-        </Small>
-        <View className="gap-2">
-          <H3 className="text-left text-[32px] uppercase leading-[34px]">
-            Choose{"\n"}your challenge
-          </H3>
-          <Muted className="text-base leading-6">
-            Match the web catalog and jump into the mode that fits the pace,
-            board, and stakes you want right now.
-          </Muted>
-        </View>
+      <View className="gap-2 pt-4">
+        <H3 className="text-center text-xl">{PLAY_SCREEN_CONTENT.heading}</H3>
+        <Muted className="text-center text-sm">
+          {PLAY_SCREEN_CONTENT.description}
+        </Muted>
       </View>
 
       <View className="gap-4">
@@ -131,7 +124,7 @@ export const PlayScreen = () => {
             <Card
               key={mode.id}
               className={cn(
-                "gap-0 overflow-hidden rounded-3xl border-border/60 py-0",
+                "gap-0 overflow-hidden rounded-4xl border-border/60 py-0",
                 isPending && styles.halo,
               )}
             >
@@ -145,18 +138,20 @@ export const PlayScreen = () => {
                 <CardContent className="flex-row items-center gap-4 px-4 py-4">
                   <View
                     className={cn(
-                      "size-14 items-center justify-center rounded-2xl border",
+                      "size-10 items-center justify-center rounded-xl",
                       styles.badge,
                     )}
                   >
                     <Icon
                       as={IconComponent}
-                      className={cn("size-6", styles.badgeIcon)}
+                      className={cn("size-4", styles.badgeIcon)}
                     />
                   </View>
                   <View className="min-w-0 flex-1 gap-1">
-                    <H6 className="text-base text-foreground">{mode.title}</H6>
-                    <Muted className="mt-0 text-sm leading-5">
+                    <H6 className="text-center text-sm font-semibold text-foreground">
+                      {mode.title}
+                    </H6>
+                    <Muted className="mt-0 text-center text-xs">
                       {mode.description}
                     </Muted>
                   </View>

--- a/src/ui/mobile/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/mobile/modules/play/screens/PlayScreen.tsx
@@ -135,7 +135,7 @@ export const PlayScreen = () => {
                 disabled={isCreating}
                 onPress={() => handleSelectMode(mode)}
               >
-                <CardContent className="flex-row items-center gap-4 px-4 py-4">
+                <CardContent className="min-h-20 flex-row items-center gap-4 px-4 py-4">
                   <View
                     className={cn(
                       "size-10 items-center justify-center rounded-xl",
@@ -147,7 +147,7 @@ export const PlayScreen = () => {
                       className={cn("size-4", styles.badgeIcon)}
                     />
                   </View>
-                  <View className="min-w-0 flex-1 gap-1">
+                  <View className="min-w-0 flex-1 items-center justify-center gap-1">
                     <H6 className="text-center text-sm font-semibold text-foreground">
                       {mode.title}
                     </H6>
@@ -155,14 +155,16 @@ export const PlayScreen = () => {
                       {mode.description}
                     </Muted>
                   </View>
-                  {isPending ? (
-                    <ActivityIndicator style={stylesheets.spinner} />
-                  ) : (
-                    <Icon
-                      as={ChevronRight}
-                      className="size-5 text-muted-foreground"
-                    />
-                  )}
+                  <View className="size-5 items-center justify-center">
+                    {isPending ? (
+                      <ActivityIndicator style={stylesheets.spinner} />
+                    ) : (
+                      <Icon
+                        as={ChevronRight}
+                        className="size-5 text-muted-foreground"
+                      />
+                    )}
+                  </View>
                 </CardContent>
               </Pressable>
             </Card>

--- a/src/ui/mobile/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/mobile/modules/play/screens/PlayScreen.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+
+import { router } from "expo-router";
+import type { LucideIcon } from "lucide-react-native";
+import {
+  ChevronRight,
+  Clock,
+  Grid2x2,
+  Grid3x3,
+  Hash,
+  Medal,
+  Trophy,
+} from "lucide-react-native";
+import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
+
+import { useMobileHeader } from "@/ui/mobile/application/providers/MobileHeaderProvider";
+import { H3, H6, Muted, Small } from "@/ui/mobile/components/Typography";
+import { Card, CardContent } from "@/ui/mobile/components/ui/card";
+import { Icon } from "@/ui/mobile/components/ui/icon";
+import { cn } from "@/ui/mobile/lib/utils";
+import { PLAY_MODES, type PlayMode } from "@/ui/shared/play/constants/modes";
+import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
+
+const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
+  hash: Hash,
+  trophy: Trophy,
+  medal: Medal,
+  clock: Clock,
+  "grid-4": Grid2x2,
+  "grid-6": Grid3x3,
+};
+
+const modeStyles: Record<
+  PlayMode["tone"],
+  { badge: string; badgeIcon: string; halo: string }
+> = {
+  emerald: {
+    badge: "border-emerald-500/20 bg-emerald-500/10",
+    badgeIcon: "text-emerald-500",
+    halo: "bg-emerald-500/10",
+  },
+  yellow: {
+    badge: "border-yellow-500/20 bg-yellow-500/10",
+    badgeIcon: "text-yellow-500",
+    halo: "bg-yellow-500/10",
+  },
+  fuchsia: {
+    badge: "border-fuchsia-500/20 bg-fuchsia-500/10",
+    badgeIcon: "text-fuchsia-500",
+    halo: "bg-fuchsia-500/10",
+  },
+  orange: {
+    badge: "border-orange-500/20 bg-orange-500/10",
+    badgeIcon: "text-orange-500",
+    halo: "bg-orange-500/10",
+  },
+  sky: {
+    badge: "border-sky-500/20 bg-sky-500/10",
+    badgeIcon: "text-sky-500",
+    halo: "bg-sky-500/10",
+  },
+  violet: {
+    badge: "border-violet-500/20 bg-violet-500/10",
+    badgeIcon: "text-violet-500",
+    halo: "bg-violet-500/10",
+  },
+};
+
+export const PlayScreen = () => {
+  const { setHeader } = useMobileHeader();
+  const { createGame, isCreating } = useCreateGame();
+  const [pendingModeId, setPendingModeId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setHeader({
+      title: "Select Mode",
+      eyebrow: "New Game",
+    });
+
+    return () => {
+      setHeader(null);
+    };
+  }, [setHeader]);
+
+  const handleSelectMode = async (mode: PlayMode) => {
+    setPendingModeId(mode.id);
+
+    try {
+      const gameId = await createGame(mode.config);
+
+      if (!gameId) {
+        return;
+      }
+
+      router.push({
+        pathname: "/match",
+        params: { gameId },
+      });
+    } finally {
+      setPendingModeId(null);
+    }
+  };
+
+  return (
+    <View className="flex-1 gap-8 pb-12">
+      <View className="gap-4 pt-2">
+        <Small
+          variant="label"
+          className="w-fit rounded-full border border-border/60 bg-card px-3 py-2 text-[10px] text-primary"
+        >
+          Fresh Match
+        </Small>
+        <View className="gap-2">
+          <H3 className="text-left text-[32px] uppercase leading-[34px]">
+            Choose{"\n"}your challenge
+          </H3>
+          <Muted className="text-base leading-6">
+            Match the web catalog and jump into the mode that fits the pace,
+            board, and stakes you want right now.
+          </Muted>
+        </View>
+      </View>
+
+      <View className="gap-4">
+        {PLAY_MODES.map((mode) => {
+          const IconComponent = modeIcons[mode.icon];
+          const styles = modeStyles[mode.tone];
+          const isPending = pendingModeId === mode.id;
+
+          return (
+            <Card
+              key={mode.id}
+              className={cn(
+                "gap-0 overflow-hidden rounded-3xl border-border/60 py-0",
+                isPending && styles.halo,
+              )}
+            >
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={mode.title}
+                className={cn("active:bg-card/80", isCreating && "opacity-70")}
+                disabled={isCreating}
+                onPress={() => handleSelectMode(mode)}
+              >
+                <CardContent className="flex-row items-center gap-4 px-4 py-4">
+                  <View
+                    className={cn(
+                      "size-14 items-center justify-center rounded-2xl border",
+                      styles.badge,
+                    )}
+                  >
+                    <Icon
+                      as={IconComponent}
+                      className={cn("size-6", styles.badgeIcon)}
+                    />
+                  </View>
+                  <View className="min-w-0 flex-1 gap-1">
+                    <H6 className="text-base text-foreground">{mode.title}</H6>
+                    <Muted className="mt-0 text-sm leading-5">
+                      {mode.description}
+                    </Muted>
+                  </View>
+                  {isPending ? (
+                    <ActivityIndicator style={stylesheets.spinner} />
+                  ) : (
+                    <Icon
+                      as={ChevronRight}
+                      className="size-5 text-muted-foreground"
+                    />
+                  )}
+                </CardContent>
+              </Pressable>
+            </Card>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const stylesheets = StyleSheet.create({
+  spinner: {
+    height: 20,
+    width: 20,
+  },
+});

--- a/src/ui/mobile/routes/match.tsx
+++ b/src/ui/mobile/routes/match.tsx
@@ -1,0 +1,114 @@
+import { useEffect } from "react";
+
+import { router, useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, View } from "react-native";
+
+import { useGameById } from "@/infrastructure/convex/GameApi";
+import { useMobileHeader } from "@/ui/mobile/application/providers/MobileHeaderProvider";
+import { H3, H6, Muted, P } from "@/ui/mobile/components/Typography";
+import { Button } from "@/ui/mobile/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/mobile/components/ui/card";
+import { RequireAuth } from "@/ui/mobile/router/auth";
+
+const MatchRouteContent = () => {
+  const { gameId } = useLocalSearchParams<{ gameId?: string }>();
+  const { setHeader } = useMobileHeader();
+  const game = useGameById(typeof gameId === "string" ? gameId : null);
+
+  useEffect(() => {
+    setHeader({
+      title: "Match",
+      eyebrow: "Live Session",
+      leftSlot: (
+        <Button size="sm" variant="ghost" onPress={() => router.back()}>
+          <P>Back</P>
+        </Button>
+      ),
+    });
+
+    return () => {
+      setHeader(null);
+    };
+  }, [setHeader]);
+
+  if (typeof gameId !== "string") {
+    return (
+      <View className="flex-1 justify-center">
+        <Card className="rounded-3xl border-border/60">
+          <CardHeader>
+            <CardTitle>Missing match</CardTitle>
+            <CardDescription>
+              A game id is required before the mobile match screen can load.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </View>
+    );
+  }
+
+  if (game === undefined) {
+    return (
+      <View className="flex-1 items-center justify-center gap-3">
+        <ActivityIndicator />
+        <Muted>Loading match...</Muted>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 gap-6 pb-12">
+      <View className="gap-2 pt-2">
+        <H3 className="text-left">Game ready</H3>
+        <Muted className="text-base leading-6">
+          The new game was created from the mobile play flow. This route is now
+          wired and ready for the full mobile match board implementation.
+        </Muted>
+      </View>
+
+      <Card className="rounded-3xl border-border/60">
+        <CardHeader>
+          <CardTitle>Session details</CardTitle>
+          <CardDescription>
+            Use this data to verify the selected mode.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Muted className="mt-0">Game ID</Muted>
+            <H6 className="text-right">{gameId}</H6>
+          </View>
+          <View className="flex-row items-center justify-between">
+            <Muted className="mt-0">Status</Muted>
+            <H6 className="text-right">{game?.status ?? "Not found"}</H6>
+          </View>
+          <View className="flex-row items-center justify-between">
+            <Muted className="mt-0">Grid</Muted>
+            <H6 className="text-right">
+              {game ? `${game.gridSize}x${game.gridSize}` : "Unavailable"}
+            </H6>
+          </View>
+          <View className="flex-row items-center justify-between">
+            <Muted className="mt-0">Format</Muted>
+            <H6 className="text-right">
+              {game ? game.match.format.toUpperCase() : "Unavailable"}
+            </H6>
+          </View>
+        </CardContent>
+      </Card>
+    </View>
+  );
+};
+
+export default function MatchRoute() {
+  return (
+    <RequireAuth>
+      <MatchRouteContent />
+    </RequireAuth>
+  );
+}

--- a/src/ui/mobile/routes/play.tsx
+++ b/src/ui/mobile/routes/play.tsx
@@ -1,0 +1,10 @@
+import { PlayScreen } from "@/ui/mobile/modules/play/screens/PlayScreen";
+import { RequireAuth } from "@/ui/mobile/router/auth";
+
+export default function PlayRoute() {
+  return (
+    <RequireAuth>
+      <PlayScreen />
+    </RequireAuth>
+  );
+}

--- a/src/ui/shared/play/constants/modes.ts
+++ b/src/ui/shared/play/constants/modes.ts
@@ -1,0 +1,78 @@
+import type { GameConfig } from "@/domain/entities/GameConfig";
+
+type PlayModeIcon = "hash" | "trophy" | "medal" | "clock" | "grid-4" | "grid-6";
+type PlayModeTone =
+  | "emerald"
+  | "yellow"
+  | "fuchsia"
+  | "orange"
+  | "sky"
+  | "violet";
+
+type PlayMode = {
+  id: string;
+  title: string;
+  description: string;
+  icon: PlayModeIcon;
+  tone: PlayModeTone;
+  config: GameConfig;
+};
+
+const PLAY_MODES: readonly PlayMode[] = [
+  {
+    id: "classic",
+    title: "Classic Mode",
+    description: "Standard rules. The original game.",
+    icon: "hash",
+    tone: "emerald",
+    config: { gridSize: 3, winLength: 3, matchFormat: "single" },
+  },
+  {
+    id: "best-of-three",
+    title: "Best of Three",
+    description: "First to 2 wins takes the crown.",
+    icon: "trophy",
+    tone: "yellow",
+    config: { gridSize: 3, winLength: 3, matchFormat: "bo3" },
+  },
+  {
+    id: "best-of-five",
+    title: "Best of Five",
+    description: "An extended battle for dominance.",
+    icon: "medal",
+    tone: "fuchsia",
+    config: { gridSize: 3, winLength: 3, matchFormat: "bo5" },
+  },
+  {
+    id: "time-challenge",
+    title: "Time Challenge",
+    description: "Make your move before time runs out.",
+    icon: "clock",
+    tone: "orange",
+    config: {
+      gridSize: 3,
+      winLength: 3,
+      matchFormat: "single",
+      isTimed: true,
+    },
+  },
+  {
+    id: "grid-4x4",
+    title: "4x4 Grid",
+    description: "Connect 4 to win on a bigger board.",
+    icon: "grid-4",
+    tone: "sky",
+    config: { gridSize: 4, winLength: 3, matchFormat: "single" },
+  },
+  {
+    id: "grid-6x6",
+    title: "6x6 Grid",
+    description: "Complex strategy on a massive field.",
+    icon: "grid-6",
+    tone: "violet",
+    config: { gridSize: 6, winLength: 3, matchFormat: "single" },
+  },
+] as const;
+
+export type { PlayMode, PlayModeIcon, PlayModeTone };
+export { PLAY_MODES };

--- a/src/ui/shared/play/constants/modes.ts
+++ b/src/ui/shared/play/constants/modes.ts
@@ -18,6 +18,13 @@ type PlayMode = {
   config: GameConfig;
 };
 
+const PLAY_SCREEN_CONTENT = {
+  eyebrow: "New Game",
+  title: "Select Mode",
+  heading: "Choose your challenge",
+  description: "Pick a mode to jump into a match with unique rules and stakes.",
+} as const;
+
 const PLAY_MODES: readonly PlayMode[] = [
   {
     id: "classic",
@@ -75,4 +82,4 @@ const PLAY_MODES: readonly PlayMode[] = [
 ] as const;
 
 export type { PlayMode, PlayModeIcon, PlayModeTone };
-export { PLAY_MODES };
+export { PLAY_MODES, PLAY_SCREEN_CONTENT };

--- a/src/ui/shared/play/hooks/useCreateGame.test.ts
+++ b/src/ui/shared/play/hooks/useCreateGame.test.ts
@@ -56,7 +56,7 @@ describe("useCreateGame", () => {
 
     const { result } = renderHook(() => useCreateGame());
 
-    let firstRequest: Promise<string | null> | undefined;
+    let firstRequest!: Promise<string | null>;
 
     act(() => {
       firstRequest = result.current.createGame(config);

--- a/src/ui/shared/play/hooks/useCreateGame.test.ts
+++ b/src/ui/shared/play/hooks/useCreateGame.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
+import { gameRepository } from "@/infrastructure/convex/repository/gameRepository";
+
+import { useCreateGame } from "./useCreateGame";
+
+vi.mock("@/application/games/findOrCreateGameUseCase", () => ({
+  findOrCreateGameUseCase: vi.fn(),
+}));
+
+describe("useCreateGame", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a game through the shared repository path", async () => {
+    const config = {
+      gridSize: 3,
+      winLength: 3,
+      matchFormat: "single" as const,
+    };
+    vi.mocked(findOrCreateGameUseCase).mockResolvedValue("game-123");
+
+    const { result } = renderHook(() => useCreateGame());
+
+    let gameId: string | null = null;
+
+    await act(async () => {
+      gameId = await result.current.createGame(config);
+    });
+
+    expect(gameId).toBe("game-123");
+    expect(findOrCreateGameUseCase).toHaveBeenCalledWith(
+      gameRepository,
+      config,
+    );
+    expect(result.current.isCreating).toBe(false);
+  });
+
+  it("ignores duplicate requests while a game is being created", async () => {
+    const config = {
+      gridSize: 3,
+      winLength: 3,
+      matchFormat: "single" as const,
+    };
+    let resolveRequest: (value: string) => void = () => {
+      throw new Error("resolveRequest not initialized");
+    };
+    vi.mocked(findOrCreateGameUseCase).mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useCreateGame());
+
+    let firstRequest: Promise<string | null> | undefined;
+
+    act(() => {
+      firstRequest = result.current.createGame(config);
+    });
+
+    expect(result.current.isCreating).toBe(true);
+
+    let secondResult: string | null = "unexpected";
+
+    await act(async () => {
+      secondResult = await result.current.createGame(config);
+    });
+
+    expect(secondResult).toBeNull();
+    expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
+
+    let firstResult: string | null = null;
+
+    await act(async () => {
+      resolveRequest("game-999");
+      firstResult = await firstRequest;
+    });
+
+    expect(firstResult).toBe("game-999");
+    expect(result.current.isCreating).toBe(false);
+  });
+});

--- a/src/ui/shared/play/hooks/useCreateGame.ts
+++ b/src/ui/shared/play/hooks/useCreateGame.ts
@@ -1,0 +1,28 @@
+import { useCallback, useRef, useState } from "react";
+
+import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
+import type { GameConfig } from "@/domain/entities/GameConfig";
+import { gameRepository } from "@/infrastructure/convex/repository/gameRepository";
+
+export const useCreateGame = () => {
+  const inFlightRef = useRef(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const createGame = useCallback(async (config: GameConfig) => {
+    if (inFlightRef.current) {
+      return null;
+    }
+
+    inFlightRef.current = true;
+    setIsCreating(true);
+
+    try {
+      return await findOrCreateGameUseCase(gameRepository, config);
+    } finally {
+      inFlightRef.current = false;
+      setIsCreating(false);
+    }
+  }, []);
+
+  return { createGame, isCreating };
+};

--- a/src/ui/shared/play/hooks/useCreateGame.ts
+++ b/src/ui/shared/play/hooks/useCreateGame.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
 import type { GameConfig } from "@/domain/entities/GameConfig";
@@ -8,7 +8,7 @@ export const useCreateGame = () => {
   const inFlightRef = useRef(false);
   const [isCreating, setIsCreating] = useState(false);
 
-  const createGame = useCallback(async (config: GameConfig) => {
+  const createGame = async (config: GameConfig) => {
     if (inFlightRef.current) {
       return null;
     }
@@ -22,7 +22,7 @@ export const useCreateGame = () => {
       inFlightRef.current = false;
       setIsCreating(false);
     }
-  }, []);
+  };
 
   return { createGame, isCreating };
 };

--- a/src/ui/shared/play/style/playModeStyles.ts
+++ b/src/ui/shared/play/style/playModeStyles.ts
@@ -1,0 +1,95 @@
+import type { PlayMode } from "@/ui/shared/play/constants/modes";
+
+type PlatformPlayModeStyle = {
+  background: string;
+  iconColor: string;
+  pressHalo: string;
+};
+
+type PlayModeStyle = {
+  web: PlatformPlayModeStyle;
+  mobile: PlatformPlayModeStyle;
+};
+
+type ToneStyleToken = {
+  mobileColor: keyof typeof toneColorClasses;
+  webColor?: keyof typeof toneColorClasses;
+};
+
+const toneStyleTokens: Record<PlayMode["tone"], ToneStyleToken> = {
+  emerald: {
+    mobileColor: "emerald",
+  },
+  yellow: {
+    mobileColor: "yellow",
+  },
+  fuchsia: {
+    mobileColor: "fuchsia",
+  },
+  orange: {
+    mobileColor: "orange",
+  },
+  sky: {
+    mobileColor: "sky",
+  },
+  violet: {
+    mobileColor: "violet",
+    webColor: "purple",
+  },
+};
+
+const toneColorClasses = {
+  emerald: {
+    background: "bg-emerald-500/15",
+    iconColor: "text-emerald-500",
+    pressHalo: "active:bg-emerald-500/10",
+  },
+  yellow: {
+    background: "bg-yellow-500/15",
+    iconColor: "text-yellow-500",
+    pressHalo: "active:bg-yellow-500/10",
+  },
+  fuchsia: {
+    background: "bg-fuchsia-500/15",
+    iconColor: "text-fuchsia-500",
+    pressHalo: "active:bg-fuchsia-500/10",
+  },
+  orange: {
+    background: "bg-orange-500/15",
+    iconColor: "text-orange-500",
+    pressHalo: "active:bg-orange-500/10",
+  },
+  sky: {
+    background: "bg-sky-500/15",
+    iconColor: "text-sky-500",
+    pressHalo: "active:bg-sky-500/10",
+  },
+  violet: {
+    background: "bg-violet-500/15",
+    iconColor: "text-violet-500",
+    pressHalo: "active:bg-violet-500/10",
+  },
+  purple: {
+    background: "bg-purple-500/15",
+    iconColor: "text-purple-500",
+    pressHalo: "active:bg-purple-500/10",
+  },
+} satisfies Record<string, PlatformPlayModeStyle>;
+
+export const playModeStyles: Record<PlayMode["tone"], PlayModeStyle> = {
+  emerald: resolvePlayModeStyle(toneStyleTokens.emerald),
+  yellow: resolvePlayModeStyle(toneStyleTokens.yellow),
+  fuchsia: resolvePlayModeStyle(toneStyleTokens.fuchsia),
+  orange: resolvePlayModeStyle(toneStyleTokens.orange),
+  sky: resolvePlayModeStyle(toneStyleTokens.sky),
+  violet: resolvePlayModeStyle(toneStyleTokens.violet),
+};
+
+function resolvePlayModeStyle(tokens: ToneStyleToken): PlayModeStyle {
+  return {
+    web: toneColorClasses[tokens.webColor ?? tokens.mobileColor],
+    mobile: toneColorClasses[tokens.mobileColor],
+  };
+}
+
+export type { PlatformPlayModeStyle, PlayModeStyle };

--- a/src/ui/web/hooks/useGame.ts
+++ b/src/ui/web/hooks/useGame.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import { heartbeatUseCase } from "@/application/games/heartbeatUseCase";
 import type { GameId } from "@/domain/entities/Game";
@@ -25,14 +25,13 @@ export const useGameHeartbeat = ({
   jitterMs = DEFAULT_JITTER_MS,
 }: HeartbeatParams): void => {
   const gameIdRef = useRef<GameId | undefined>(gameId);
-  const heartbeatRef = useRef(sendHeartbeat);
   const intervalMsRef = useRef(intervalMs);
   const jitterMsRef = useRef(jitterMs);
   const intervalIdRef = useRef<number | null>(null);
   const timeoutIdRef = useRef<number | null>(null);
   const inFlightRef = useRef(false);
 
-  const stopInterval = useCallback(() => {
+  const stopInterval = useEffectEvent(() => {
     if (intervalIdRef.current === null) {
       if (timeoutIdRef.current === null) {
         return;
@@ -48,9 +47,9 @@ export const useGameHeartbeat = ({
       clearTimeout(timeoutIdRef.current);
       timeoutIdRef.current = null;
     }
-  }, []);
+  });
 
-  const triggerHeartbeat = useCallback(async () => {
+  const triggerHeartbeat = useEffectEvent(async () => {
     const currentGameId = gameIdRef.current;
     if (!currentGameId || inFlightRef.current) {
       return;
@@ -58,15 +57,15 @@ export const useGameHeartbeat = ({
 
     inFlightRef.current = true;
     try {
-      await heartbeatRef.current({ gameId: currentGameId });
+      await sendHeartbeat({ gameId: currentGameId });
     } catch (error) {
       console.debug("Game heartbeat failed.", error);
     } finally {
       inFlightRef.current = false;
     }
-  }, []);
+  });
 
-  const triggerHeartbeatWithJitter = useCallback(() => {
+  const triggerHeartbeatWithJitter = useEffectEvent(() => {
     const jitter = jitterMsRef.current;
     const delay = jitter > 0 ? Math.floor(Math.random() * (jitter + 1)) : 0;
 
@@ -82,9 +81,9 @@ export const useGameHeartbeat = ({
     timeoutIdRef.current = setTimeout(() => {
       void triggerHeartbeat();
     }, delay);
-  }, [triggerHeartbeat]);
+  });
 
-  const startInterval = useCallback(() => {
+  const startInterval = useEffectEvent(() => {
     if (intervalIdRef.current !== null || !gameIdRef.current) {
       return;
     }
@@ -92,7 +91,7 @@ export const useGameHeartbeat = ({
     intervalIdRef.current = setInterval(() => {
       triggerHeartbeatWithJitter();
     }, intervalMsRef.current);
-  }, [triggerHeartbeatWithJitter]);
+  });
 
   useEffect(() => {
     gameIdRef.current = gameId;
@@ -115,7 +114,7 @@ export const useGameHeartbeat = ({
         startInterval();
       }
     }
-  }, [gameId, startInterval, stopInterval, triggerHeartbeat]);
+  }, [gameId]);
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -143,7 +142,7 @@ export const useGameHeartbeat = ({
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       stopInterval();
     };
-  }, [startInterval, stopInterval, triggerHeartbeat]);
+  }, []);
 };
 
 type UseTurnTimerParams = {
@@ -178,6 +177,13 @@ export const useTurnTimer = ({
   const [now, setNow] = useState(() => Date.now());
   const timeoutRef = useRef<number | null>(null);
   const hasTriggeredRef = useRef(false);
+  const handleExpire = useEffectEvent(async () => {
+    if (!onExpire) {
+      return;
+    }
+
+    await onExpire();
+  });
 
   useEffect(() => {
     if (!isActive) {
@@ -202,6 +208,7 @@ export const useTurnTimer = ({
   }, [deadlineTime, durationMs, isActive, expireDelayMs]);
 
   const hasTimer = Boolean(durationMs);
+  const hasOnExpire = Boolean(onExpire);
   const resolvedDeadline = deadlineTime ?? null;
   const isExpired =
     isActive && resolvedDeadline !== null && now > resolvedDeadline && hasTimer;
@@ -212,20 +219,20 @@ export const useTurnTimer = ({
   const progress = hasTimer ? remainingMs / (durationMs as number) : 0;
 
   useEffect(() => {
-    if (!isExpired || !onExpire || hasTriggeredRef.current) {
+    if (!isExpired || !hasOnExpire || hasTriggeredRef.current) {
       return;
     }
 
     hasTriggeredRef.current = true;
     if (expireDelayMs <= 0) {
-      void onExpire();
+      void handleExpire();
       return;
     }
 
     timeoutRef.current = setTimeout(() => {
-      void onExpire();
+      void handleExpire();
     }, expireDelayMs);
-  }, [expireDelayMs, isExpired, onExpire]);
+  }, [expireDelayMs, hasOnExpire, isExpired]);
 
   return { isExpired, remainingMs, progress };
 };

--- a/src/ui/web/modules/play/screens/PlayScreen.test.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.test.tsx
@@ -1,37 +1,28 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
-import { gameRepository } from "@/infrastructure/convex/repository/gameRepository";
+import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
 
 import { PlayScreen } from "./PlayScreen";
 
 const navigateMock = vi.fn();
-
-const invokeReactClick = (element: HTMLElement) => {
-  const propsKey = Object.keys(element).find((key) =>
-    key.startsWith("__reactProps$"),
-  );
-  if (!propsKey) {
-    throw new Error("React props key not found");
-  }
-  const reactProps = (
-    element as unknown as Record<string, { onClick?: () => void }>
-  )[propsKey];
-  reactProps.onClick?.();
-};
+const createGameMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigateMock,
 }));
 
-vi.mock("@/application/games/findOrCreateGameUseCase", () => ({
-  findOrCreateGameUseCase: vi.fn(),
+vi.mock("@/ui/shared/play/hooks/useCreateGame", () => ({
+  useCreateGame: vi.fn(),
 }));
 
 describe("PlayScreen", () => {
   beforeEach(() => {
     navigateMock.mockReset();
-    vi.mocked(findOrCreateGameUseCase).mockReset();
+    createGameMock.mockReset();
+    vi.mocked(useCreateGame).mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+    });
   });
 
   it("renders all game modes", () => {
@@ -46,13 +37,13 @@ describe("PlayScreen", () => {
   });
 
   it("creates and navigates to match when selecting a mode", async () => {
-    vi.mocked(findOrCreateGameUseCase).mockResolvedValue("game-123");
+    createGameMock.mockResolvedValue("game-123");
     render(<PlayScreen />);
 
     fireEvent.click(screen.getByRole("button", { name: /classic mode/i }));
 
     await waitFor(() => {
-      expect(findOrCreateGameUseCase).toHaveBeenCalledWith(gameRepository, {
+      expect(createGameMock).toHaveBeenCalledWith({
         gridSize: 3,
         winLength: 3,
         matchFormat: "single",
@@ -64,40 +55,29 @@ describe("PlayScreen", () => {
     });
   });
 
-  it("prevents duplicate submissions while creating a game", async () => {
-    let resolveCall: (value: string) => void = () => {
-      throw new Error("resolveCall not initialized");
-    };
-    vi.mocked(findOrCreateGameUseCase).mockImplementation(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveCall = resolve;
-        }),
-    );
+  it("does not navigate when the shared create flow returns null", async () => {
+    createGameMock.mockResolvedValue(null);
     render(<PlayScreen />);
 
-    const classicModeButton = screen.getByRole("button", {
-      name: /classic mode/i,
-    });
-    fireEvent.click(classicModeButton);
+    fireEvent.click(screen.getByRole("button", { name: /classic mode/i }));
 
     await waitFor(() => {
-      expect(classicModeButton).toBeDisabled();
+      expect(createGameMock).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /best of three/i }));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
 
-    expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
-
-    invokeReactClick(classicModeButton);
-    expect(findOrCreateGameUseCase).toHaveBeenCalledTimes(1);
-
-    resolveCall("game-999");
-    await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith({
-        to: "/match",
-        search: { gameId: "game-999" },
-      });
+  it("disables mode buttons while the shared create flow is busy", () => {
+    vi.mocked(useCreateGame).mockReturnValue({
+      createGame: createGameMock,
+      isCreating: true,
     });
+
+    render(<PlayScreen />);
+
+    expect(
+      screen.getByRole("button", { name: /classic mode/i }),
+    ).toBeDisabled();
   });
 });

--- a/src/ui/web/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.tsx
@@ -11,7 +11,11 @@ import {
 
 import { useNavigate } from "@tanstack/react-router";
 
-import { PLAY_MODES, type PlayMode } from "@/ui/shared/play/constants/modes";
+import {
+  PLAY_MODES,
+  PLAY_SCREEN_CONTENT,
+  type PlayMode,
+} from "@/ui/shared/play/constants/modes";
 import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
 import { Header } from "@/ui/web/components/Header";
 import { H3, H6, Muted } from "@/ui/web/components/Typography";
@@ -79,11 +83,14 @@ export const PlayScreen = () => {
 
   return (
     <section className="mx-auto flex w-full max-w-xl flex-col gap-8 md:gap-20 pb-12 h-full">
-      <Header title="Select Mode" eyebrow="New Game" />
+      <Header
+        title={PLAY_SCREEN_CONTENT.title}
+        eyebrow={PLAY_SCREEN_CONTENT.eyebrow}
+      />
       <div className="flex flex-col gap-2 text-center">
-        <H3 className="text-xl">Choose your challenge</H3>
+        <H3 className="text-xl">{PLAY_SCREEN_CONTENT.heading}</H3>
         <Muted className="text-sm text-muted-foreground">
-          Pick a mode to jump into a match with unique rules and stakes.
+          {PLAY_SCREEN_CONTENT.description}
         </Muted>
       </div>
       <ItemGroup className="gap-4 md:grid md:grid-cols-2">

--- a/src/ui/web/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.tsx
@@ -17,6 +17,7 @@ import {
   type PlayMode,
 } from "@/ui/shared/play/constants/modes";
 import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
+import { playModeStyles } from "@/ui/shared/play/style/playModeStyles";
 import { Header } from "@/ui/web/components/Header";
 import { H3, H6, Muted } from "@/ui/web/components/Typography";
 import {
@@ -35,33 +36,6 @@ const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
   clock: Clock,
   "grid-4": Grid2x2,
   "grid-6": Grid3x3,
-};
-
-const modeStyles: Record<PlayMode["tone"], { accent: string; bg: string }> = {
-  emerald: {
-    accent: "text-emerald-500",
-    bg: "bg-emerald-500/15",
-  },
-  yellow: {
-    accent: "text-yellow-500",
-    bg: "bg-yellow-500/15",
-  },
-  fuchsia: {
-    accent: "text-fuchsia-500",
-    bg: "bg-fuchsia-500/15",
-  },
-  orange: {
-    accent: "text-orange-500",
-    bg: "bg-orange-500/15",
-  },
-  sky: {
-    accent: "text-sky-500",
-    bg: "bg-sky-500/15",
-  },
-  violet: {
-    accent: "text-purple-500",
-    bg: "bg-purple-500/15",
-  },
 };
 
 export const PlayScreen = () => {
@@ -96,16 +70,17 @@ export const PlayScreen = () => {
       <ItemGroup className="gap-4 md:grid md:grid-cols-2">
         {PLAY_MODES.map((mode) => {
           const Icon = modeIcons[mode.icon];
-          const styles = modeStyles[mode.tone];
+          const styles = playModeStyles[mode.tone].web;
 
           return (
             <Item
               key={mode.id}
               asChild
               variant="outline"
-              className={
-                "bg-card hover:bg-card/70 cursor-pointer min-h-20 md:min-h-38 md:flex-col md:items-center md:gap-0 rounded-4xl disabled:cursor-not-allowed disabled:opacity-70"
-              }
+              className={cn(
+                "bg-card hover:bg-card/70 cursor-pointer min-h-20 md:min-h-38 md:flex-col md:items-center md:gap-0 rounded-4xl disabled:cursor-not-allowed disabled:opacity-70",
+                styles.pressHalo,
+              )}
             >
               <button
                 type="button"
@@ -114,7 +89,11 @@ export const PlayScreen = () => {
               >
                 <ItemMedia
                   variant="icon"
-                  className={cn("size-10 rounded-xl", styles.accent, styles.bg)}
+                  className={cn(
+                    "size-10 rounded-xl",
+                    styles.iconColor,
+                    styles.background,
+                  )}
                 >
                   <Icon className="size-4" />
                 </ItemMedia>

--- a/src/ui/web/modules/play/screens/PlayScreen.tsx
+++ b/src/ui/web/modules/play/screens/PlayScreen.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useState } from "react";
-
+import type { LucideIcon } from "lucide-react";
 import {
   ChevronRight,
   Clock,
@@ -12,8 +11,8 @@ import {
 
 import { useNavigate } from "@tanstack/react-router";
 
-import { findOrCreateGameUseCase } from "@/application/games/findOrCreateGameUseCase";
-import { gameRepository } from "@/infrastructure/convex/repository/gameRepository";
+import { PLAY_MODES, type PlayMode } from "@/ui/shared/play/constants/modes";
+import { useCreateGame } from "@/ui/shared/play/hooks/useCreateGame";
 import { Header } from "@/ui/web/components/Header";
 import { H3, H6, Muted } from "@/ui/web/components/Typography";
 import {
@@ -25,93 +24,58 @@ import {
 } from "@/ui/web/components/ui/item";
 import { cn } from "@/ui/web/lib/utils";
 
-const modes = [
-  {
-    id: "classic",
-    title: "Classic Mode",
-    description: "Standard rules. The original game.",
-    icon: Hash,
+const modeIcons: Record<PlayMode["icon"], LucideIcon> = {
+  hash: Hash,
+  trophy: Trophy,
+  medal: Medal,
+  clock: Clock,
+  "grid-4": Grid2x2,
+  "grid-6": Grid3x3,
+};
+
+const modeStyles: Record<PlayMode["tone"], { accent: string; bg: string }> = {
+  emerald: {
     accent: "text-emerald-500",
     bg: "bg-emerald-500/15",
-    config: { gridSize: 3, winLength: 3, matchFormat: "single" },
   },
-  {
-    id: "best-of-three",
-    title: "Best of Three",
-    description: "First to 2 wins takes the crown.",
-    icon: Trophy,
+  yellow: {
     accent: "text-yellow-500",
     bg: "bg-yellow-500/15",
-    config: { gridSize: 3, winLength: 3, matchFormat: "bo3" },
   },
-  {
-    id: "best-of-five",
-    title: "Best of Five",
-    description: "An extended battle for dominance.",
-    icon: Medal,
+  fuchsia: {
     accent: "text-fuchsia-500",
     bg: "bg-fuchsia-500/15",
-    config: { gridSize: 3, winLength: 3, matchFormat: "bo5" },
   },
-  {
-    id: "time-challenge",
-    title: "Time Challenge",
-    description: "Make your move before time runs out.",
-    icon: Clock,
+  orange: {
     accent: "text-orange-500",
     bg: "bg-orange-500/15",
-    config: {
-      gridSize: 3,
-      winLength: 3,
-      matchFormat: "single",
-      isTimed: true,
-    },
   },
-  {
-    id: "grid-4x4",
-    title: "4x4 Grid",
-    description: "Connect 4 to win on a bigger board.",
-    icon: Grid2x2,
+  sky: {
     accent: "text-sky-500",
     bg: "bg-sky-500/15",
-    config: { gridSize: 4, winLength: 3, matchFormat: "single" },
   },
-  {
-    id: "grid-6x6",
-    title: "6x6 Grid",
-    description: "Complex strategy on a massive field.",
-    icon: Grid3x3,
+  violet: {
     accent: "text-purple-500",
     bg: "bg-purple-500/15",
-    config: { gridSize: 6, winLength: 3, matchFormat: "single" },
   },
-] as const;
+};
 
 export const PlayScreen = () => {
   const navigate = useNavigate();
-  const [isCreating, setIsCreating] = useState(false);
+  const { createGame, isCreating } = useCreateGame();
 
-  const handleSelectMode = useCallback(
-    async (mode: (typeof modes)[number]) => {
-      if (isCreating) {
-        return;
-      }
-      setIsCreating(true);
-      try {
-        const gameId = await findOrCreateGameUseCase(
-          gameRepository,
-          mode.config,
-        );
-        await navigate({
-          to: "/match",
-          search: { gameId },
-        });
-      } finally {
-        setIsCreating(false);
-      }
-    },
-    [isCreating, navigate],
-  );
+  const handleSelectMode = async (mode: PlayMode) => {
+    const gameId = await createGame(mode.config);
+
+    if (!gameId) {
+      return;
+    }
+
+    await navigate({
+      to: "/match",
+      search: { gameId },
+    });
+  };
 
   return (
     <section className="mx-auto flex w-full max-w-xl flex-col gap-8 md:gap-20 pb-12 h-full">
@@ -123,8 +87,10 @@ export const PlayScreen = () => {
         </Muted>
       </div>
       <ItemGroup className="gap-4 md:grid md:grid-cols-2">
-        {modes.map((mode) => {
-          const Icon = mode.icon;
+        {PLAY_MODES.map((mode) => {
+          const Icon = modeIcons[mode.icon];
+          const styles = modeStyles[mode.tone];
+
           return (
             <Item
               key={mode.id}
@@ -141,7 +107,7 @@ export const PlayScreen = () => {
               >
                 <ItemMedia
                   variant="icon"
-                  className={cn("size-10 rounded-xl", mode.accent, mode.bg)}
+                  className={cn("size-10 rounded-xl", styles.accent, styles.bg)}
                 >
                   <Icon className="size-4" />
                 </ItemMedia>


### PR DESCRIPTION
## Summary
Implement the mobile equivalent of the web `PlayScreen` so users can start a new game from mobile with the same mode catalog, structure, and overall UX intent as the web flow.

## Context
- Web already ships the feature in `src/ui/web/modules/play/screens/PlayScreen.tsx` and route wiring in `src/ui/web/routes/play.tsx`.
- Mobile currently has no `play` route or `play` module under `src/ui/mobile/`.
- The mode definitions are currently embedded in the web screen, which makes reuse across platforms harder than it should be.

## Scope
- Add a mobile `play` route and screen/module structure that mirrors the web feature at the platform-adapter level.
- Recreate the mode listing on mobile with equivalent information architecture and visual hierarchy, adapted to native components and spacing.
- Hook the selected mode into the existing shared game creation flow and navigate into the mobile match experience.
- Keep platform-specific UI concerns in `src/ui/mobile/` and avoid importing Convex types or `convex/*` directly from UI code.

## Refactor Opportunities
- Extract the playable mode metadata into a shared cross-platform module so web and mobile render from the same source of truth.
- If the create-game orchestration or selection logic is duplicated while porting, move the reusable parts into shared hooks/helpers under `src/ui/shared/` or another appropriate shared layer.
- Preserve the current architecture boundaries: shared domain/application/infrastructure stay platform-agnostic; UI adapters stay platform-specific.

## Acceptance Criteria
- Mobile has a dedicated `play` route/screen reachable through its navigation flow.
- The mobile screen exposes the same game modes currently available on web.
- Selecting a mode creates or finds a game using the shared use case/repository path and routes the user into the mobile match flow.
- Shared logic/configuration extracted during the port is reused by both web and mobile.
- Mobile tests cover the new screen behavior and any extracted shared logic.


Closes #99